### PR TITLE
Compatibility with API version 5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.matmaul.freeboxos</groupId>
 	<artifactId>freeboxos-client</artifactId>
-	<version>0.4.1</version>
+	<version>0.4.2</version>
 
 	<name>freeboxos-client</name>
 	<url>https://github.com/matmaul/freeboxos-java</url>

--- a/src/org/matmaul/freeboxos/lan/LanHostConfig.java
+++ b/src/org/matmaul/freeboxos/lan/LanHostConfig.java
@@ -5,8 +5,10 @@ import java.util.List;
 
 import org.codehaus.jackson.annotate.JsonAutoDetect;
 import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LanHostConfig {
 	protected String id;
 	protected String primary_name;


### PR DESCRIPTION
New fields in object LanHostConfig ignored.

As the documentation of the API 5.0 is not yet available, the quick solution was to ignore the new "interface" field.